### PR TITLE
Allow an end-user of this role to specify their own exposed ports + mounted volumes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,8 +3,13 @@ nginx_base_directory: '/tmp/nginx'
 nginx_container_name: 'nginx'
 nginx_docker_tag: '1.9.6'
 nginx_static_html_directory: 'defaults'
+
 nginx_exposed_ports:
   - '80:80'
+
+nginx_exposed_volumes:
+  - "{{ nginx_base_directory }}/nginx.conf:/etc/nginx/nginx.conf:ro"
+  - "{{ nginx_base_directory }}/defaults:/usr/share/nginx/html:ro"
 
 nginx_conf: |
   user root;

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,8 @@ nginx_base_directory: '/tmp/nginx'
 nginx_container_name: 'nginx'
 nginx_docker_tag: '1.9.6'
 nginx_static_html_directory: 'defaults'
+nginx_exposed_ports:
+  - '80:80'
 
 nginx_conf: |
   user root;

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,9 +4,7 @@
   docker:
     image: "nginx:{{ nginx_docker_tag }}"
     name: "{{ nginx_container_name }}"
-    volumes:
-      - "{{ nginx_base_directory }}/nginx.conf:/etc/nginx/nginx.conf:ro"
-      - "{{ nginx_base_directory }}/defaults:/usr/share/nginx/html:ro"
+    volumes: '{{ nginx_exposed_volumes }}'
     ports: '{{ nginx_exposed_ports }}'
     state: 'stopped'
     restart_policy: 'always'
@@ -20,9 +18,7 @@
   docker:
     image: "nginx:{{ nginx_docker_tag }}"
     name: "{{ nginx_container_name }}"
-    volumes:
-      - "{{ nginx_base_directory }}/nginx.conf:/etc/nginx/nginx.conf:ro"
-      - "{{ nginx_base_directory }}/defaults:/usr/share/nginx/html:ro"
+    volumes: '{{ nginx_exposed_volumes }}'
     ports: '{{ nginx_exposed_ports }}'
     state: 'started'
     restart_policy: 'always'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,7 +7,7 @@
     volumes:
       - "{{ nginx_base_directory }}/nginx.conf:/etc/nginx/nginx.conf:ro"
       - "{{ nginx_base_directory }}/defaults:/usr/share/nginx/html:ro"
-    ports: '80:80'
+    ports: '{{ nginx_exposed_ports }}'
     state: 'stopped'
     restart_policy: 'always'
     log_driver: 'syslog'
@@ -23,7 +23,7 @@
     volumes:
       - "{{ nginx_base_directory }}/nginx.conf:/etc/nginx/nginx.conf:ro"
       - "{{ nginx_base_directory }}/defaults:/usr/share/nginx/html:ro"
-    ports: '80:80'
+    ports: '{{ nginx_exposed_ports }}'
     state: 'started'
     restart_policy: 'always'
     log_driver: 'syslog'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,9 +27,7 @@
   docker:
     image: "nginx:{{ nginx_docker_tag }}"
     name: "{{ nginx_container_name }}"
-    volumes:
-      - "{{ nginx_base_directory }}/nginx.conf:/etc/nginx/nginx.conf:ro"
-      - "{{ nginx_base_directory }}/defaults:/usr/share/nginx/html:ro"
+    volumes: '{{ nginx_exposed_volumes }}'
     ports: '{{ nginx_exposed_ports }}'
     state: 'started'
     restart_policy: 'always'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,7 +30,7 @@
     volumes:
       - "{{ nginx_base_directory }}/nginx.conf:/etc/nginx/nginx.conf:ro"
       - "{{ nginx_base_directory }}/defaults:/usr/share/nginx/html:ro"
-    ports: '80:80'
+    ports: '{{ nginx_exposed_ports }}'
     state: 'started'
     restart_policy: 'always'
     log_driver: 'syslog'

--- a/tests/redirect.yml
+++ b/tests/redirect.yml
@@ -2,6 +2,9 @@
 - hosts: 'localhost'
   roles:
     - role: 'ansible-role-docker-nginx'
+      nginx_exposed_ports:
+        - '80:80'
+        - '443:443'
       sudo: true
       nginx_conf: |
         user root;


### PR DESCRIPTION
This is a much more modular approach vs prescribing that only port 80 (for example) be exposed via this role.
