### PR TITLE
Add the ability to expose docker ports, in addition to publishing them

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,9 @@ nginx_docker_tag: '1.9.6'
 nginx_static_html_directory: 'defaults'
 
 nginx_exposed_ports:
+  - '80'
+
+nginx_published_ports:
   - '80:80'
 
 nginx_exposed_volumes:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,7 +5,8 @@
     image: "nginx:{{ nginx_docker_tag }}"
     name: "{{ nginx_container_name }}"
     volumes: '{{ nginx_exposed_volumes }}'
-    ports: '{{ nginx_exposed_ports }}'
+    ports: '{{ nginx_published_ports }}'
+    expose: '{{ nginx_exposed_ports }}'
     state: 'stopped'
     restart_policy: 'always'
     log_driver: 'syslog'
@@ -19,7 +20,8 @@
     image: "nginx:{{ nginx_docker_tag }}"
     name: "{{ nginx_container_name }}"
     volumes: '{{ nginx_exposed_volumes }}'
-    ports: '{{ nginx_exposed_ports }}'
+    ports: '{{ nginx_published_ports }}'
+    expose: '{{ nginx_exposed_ports }}'
     state: 'started'
     restart_policy: 'always'
     log_driver: 'syslog'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,8 @@
     image: "nginx:{{ nginx_docker_tag }}"
     name: "{{ nginx_container_name }}"
     volumes: '{{ nginx_exposed_volumes }}'
-    ports: '{{ nginx_exposed_ports }}'
+    ports: '{{ nginx_published_ports }}'
+    expose: '{{ nginx_exposed_ports }}'
     state: 'started'
     restart_policy: 'always'
     log_driver: 'syslog'

--- a/tests/redirect.yml
+++ b/tests/redirect.yml
@@ -2,7 +2,7 @@
 - hosts: 'localhost'
   roles:
     - role: 'ansible-role-docker-nginx'
-      nginx_exposed_ports:
+      nginx_published_ports:
         - '80:80'
         - '443:443'
       sudo: true


### PR DESCRIPTION
It turns out that this is useful because Ansible _will not_ publish a port that has not been exposed inside the container, or exposed via the `expose` directive.

This also fixes terminology.
